### PR TITLE
fix: Resolve import errors in src/io module for Streamlit Cloud deplo…

### DIFF
--- a/src/io/__init__.py
+++ b/src/io/__init__.py
@@ -39,14 +39,15 @@ from .dxf_parser import DXFParser
 from .step_handler import STEPHandler
 from .stl_handler import STLHandler
 from .mesh_converter import MeshConverter
-from .universal_importer import UniversalImporter
+from .universal_importer import GeometryData, parse
 
 __all__ = [
     'DXFParser',
     'STEPHandler',
     'STLHandler',
     'MeshConverter',
-    'UniversalImporter'
+    'GeometryData',
+    'parse'
 ]
 
 __version__ = '1.0.0'
@@ -62,15 +63,14 @@ def import_file(filepath: str, **kwargs):
         **kwargs: Additional arguments passed to the specific parser
 
     Returns:
-        Dictionary with unified geometry data
+        GeometryData object with unified geometry data
 
     Example:
         >>> from src.io import import_file
         >>> geometry = import_file('model.step')
-        >>> print(f"Volume: {geometry['volume']}")
+        >>> print(f"Volume: {geometry.volume}")
     """
-    importer = UniversalImporter()
-    return importer.import_file(filepath, **kwargs)
+    return parse(filepath, **kwargs)
 
 
 def get_supported_formats():
@@ -78,11 +78,11 @@ def get_supported_formats():
     Get list of all supported file formats.
 
     Returns:
-        Dictionary mapping file extension to format category
+        List of supported file extensions
 
     Example:
         >>> from src.io import get_supported_formats
         >>> formats = get_supported_formats()
-        >>> print(formats['stl'])  # Output: 'stl'
+        >>> print(formats)  # Output: ['stl', 'obj', 'ply', 'dxf', ...]
     """
-    return UniversalImporter.get_supported_formats()
+    return ['stl', 'obj', 'ply', 'dxf', 'dwg', 'step', 'stp', 'iges', 'igs', 'brep']

--- a/src/io/dxf_parser.py
+++ b/src/io/dxf_parser.py
@@ -5,10 +5,16 @@ Handles parsing of DXF (Drawing Exchange Format) files using ezdxf library.
 Supports DXF versions R12 through R2018.
 """
 
-import ezdxf
+from __future__ import annotations
 from typing import Dict, List, Tuple, Any, Optional
 import numpy as np
 from pathlib import Path
+
+try:
+    import ezdxf
+    HAS_EZDXF = True
+except ImportError:
+    HAS_EZDXF = False
 
 
 class DXFParser:
@@ -27,6 +33,11 @@ class DXFParser:
 
     def __init__(self):
         """Initialize DXF parser."""
+        if not HAS_EZDXF:
+            raise ImportError(
+                "ezdxf library is required for DXF parsing. "
+                "Install it with: pip install ezdxf"
+            )
         self.doc = None
         self.modelspace = None
 

--- a/src/io/mesh_converter.py
+++ b/src/io/mesh_converter.py
@@ -5,10 +5,16 @@ Provides universal mesh format conversion using meshio library.
 Supports 20+ mesh formats including VTK, MSH, ANSYS, Abaqus, and more.
 """
 
-import meshio
+from __future__ import annotations
 import numpy as np
 from typing import Dict, Any, Optional, List, Union
 from pathlib import Path
+
+try:
+    import meshio
+    HAS_MESHIO = True
+except ImportError:
+    HAS_MESHIO = False
 
 
 class MeshConverter:
@@ -83,6 +89,11 @@ class MeshConverter:
 
     def __init__(self):
         """Initialize mesh converter."""
+        if not HAS_MESHIO:
+            raise ImportError(
+                "meshio library is required for mesh conversion. "
+                "Install it with: pip install meshio"
+            )
         self.mesh = None
 
     def read(self, filepath: str) -> meshio.Mesh:

--- a/src/io/step_handler.py
+++ b/src/io/step_handler.py
@@ -5,6 +5,7 @@ Handles import/export of STEP (Standard for the Exchange of Product model data) 
 using pythonocc-core and aocxchange libraries.
 """
 
+from __future__ import annotations
 from typing import Dict, Any, Optional, Tuple
 from pathlib import Path
 import numpy as np

--- a/src/io/stl_handler.py
+++ b/src/io/stl_handler.py
@@ -5,10 +5,18 @@ Handles loading, validation, and repair of STL (Stereolithography) mesh files
 using the trimesh library.
 """
 
-import trimesh
+from __future__ import annotations
 import numpy as np
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any, Optional, Tuple, TYPE_CHECKING
 from pathlib import Path
+
+try:
+    import trimesh
+    HAS_TRIMESH = True
+except ImportError:
+    HAS_TRIMESH = False
+    if TYPE_CHECKING:
+        import trimesh
 
 
 class STLHandler:
@@ -25,6 +33,11 @@ class STLHandler:
 
     def __init__(self):
         """Initialize STL handler."""
+        if not HAS_TRIMESH:
+            raise ImportError(
+                "trimesh library is required for STL handling. "
+                "Install it with: pip install trimesh"
+            )
         self.mesh = None
 
     def load_mesh(self, filepath: str, **kwargs) -> trimesh.Trimesh:

--- a/src/ui/file_import.py
+++ b/src/ui/file_import.py
@@ -27,7 +27,7 @@ from .components.file_uploader import (
 )
 
 # Import importer and visualization
-from ..io import universal_importer
+from ..io import GeometryData, parse as parse_file
 from ..visualization.preview_basic import (
     plot_geometry_data,
     create_camera_controls
@@ -148,7 +148,7 @@ def process_uploaded_file(uploaded_file):
             time.sleep(0.2)
 
             # Parse the file
-            geometry = universal_importer.parse(tmp_path)
+            geometry = parse_file(tmp_path)
 
             # Update progress
             status_text.text("📊 Extracting information...")
@@ -206,7 +206,7 @@ def process_uploaded_file(uploaded_file):
             )
 
 
-def display_geometry_info(geometry: universal_importer.GeometryData):
+def display_geometry_info(geometry: GeometryData):
     """
     Display detailed geometry information.
 
@@ -252,7 +252,7 @@ def display_geometry_info(geometry: universal_importer.GeometryData):
         st.info(f"ℹ️ {geometry.metadata['note']}")
 
 
-def display_3d_preview(geometry: universal_importer.GeometryData):
+def display_3d_preview(geometry: GeometryData):
     """
     Display interactive 3D preview of the geometry.
 
@@ -317,7 +317,7 @@ def display_3d_preview(geometry: universal_importer.GeometryData):
         st.error(f"Error rendering 3D preview: {str(e)}")
 
 
-def display_export_section(geometry: universal_importer.GeometryData, original_filename: str):
+def display_export_section(geometry: GeometryData, original_filename: str):
     """
     Display export and conversion options.
 
@@ -359,7 +359,7 @@ def display_export_section(geometry: universal_importer.GeometryData, original_f
             export_report_txt(geometry, f"{base_name}_report.txt")
 
 
-def export_as_stl(geometry: universal_importer.GeometryData, filename: str):
+def export_as_stl(geometry: GeometryData, filename: str):
     """Export geometry as STL file."""
     try:
         import struct
@@ -397,7 +397,7 @@ def export_as_stl(geometry: universal_importer.GeometryData, filename: str):
         st.error(f"Error exporting STL: {str(e)}")
 
 
-def export_as_obj(geometry: universal_importer.GeometryData, filename: str):
+def export_as_obj(geometry: GeometryData, filename: str):
     """Export geometry as OBJ file."""
     try:
         obj_data = io.StringIO()
@@ -426,7 +426,7 @@ def export_as_obj(geometry: universal_importer.GeometryData, filename: str):
         st.error(f"Error exporting OBJ: {str(e)}")
 
 
-def export_as_ply(geometry: universal_importer.GeometryData, filename: str):
+def export_as_ply(geometry: GeometryData, filename: str):
     """Export geometry as PLY file."""
     try:
         ply_data = io.StringIO()
@@ -459,7 +459,7 @@ def export_as_ply(geometry: universal_importer.GeometryData, filename: str):
         st.error(f"Error exporting PLY: {str(e)}")
 
 
-def export_vertices_csv(geometry: universal_importer.GeometryData, filename: str):
+def export_vertices_csv(geometry: GeometryData, filename: str):
     """Export vertices as CSV file."""
     try:
         csv_data = io.StringIO()
@@ -479,7 +479,7 @@ def export_vertices_csv(geometry: universal_importer.GeometryData, filename: str
         st.error(f"Error exporting CSV: {str(e)}")
 
 
-def export_metrics_json(geometry: universal_importer.GeometryData, filename: str):
+def export_metrics_json(geometry: GeometryData, filename: str):
     """Export geometry metrics as JSON."""
     try:
         import json
@@ -515,7 +515,7 @@ def export_metrics_json(geometry: universal_importer.GeometryData, filename: str
         st.error(f"Error exporting JSON: {str(e)}")
 
 
-def export_report_txt(geometry: universal_importer.GeometryData, filename: str):
+def export_report_txt(geometry: GeometryData, filename: str):
     """Export detailed report as text file."""
     try:
         report = io.StringIO()


### PR DESCRIPTION
…yment

Critical fixes for import chain: app.py -> src.ui.app -> src.ui.file_import -> src.io

Changes:
1. src/io/__init__.py:
   - Fixed: Import GeometryData and parse instead of non-existent UniversalImporter class
   - Updated __all__ exports and convenience functions

2. src/ui/file_import.py:
   - Updated imports to use GeometryData and parse directly from src.io
   - Changed all function signatures to use GeometryData instead of universal_importer.GeometryData

3. src/io/dxf_parser.py, stl_handler.py, mesh_converter.py:
   - Made external dependencies (ezdxf, trimesh, meshio) optional with try/except blocks
   - Added clear error messages when optional libraries are not installed
   - Added __future__ annotations to defer type hint evaluation

4. src/io/step_handler.py:
   - Added __future__ annotations for consistency

These changes ensure the app can import successfully even when optional CAD libraries are not installed, which is critical for Streamlit Cloud deployment.

Tested: All imports in the error chain now work correctly.