### PR TITLE
fix: Make PyVista and 3D visualization libraries optional for Streaml…

### DIFF
--- a/src/visualization/__init__.py
+++ b/src/visualization/__init__.py
@@ -5,36 +5,75 @@ This module provides professional-grade 3D visualization capabilities for CAD mo
 CFD simulation results, and mesh quality analysis using PyVista and Plotly.
 
 Main Components:
-- PyVistaViewer: Core 3D rendering engine for CAD and CFD data
-- StreamlitPyVista: Streamlit integration wrapper for interactive visualization
-- PlotlyCharts: 2D plotting utilities for convergence, residuals, and statistics
-- ExportRenderer: High-quality image and animation export functionality
-- Utils: Mesh conversion, optimization, and caching utilities
+- PyVistaViewer: Core 3D rendering engine for CAD and CFD data (optional, requires pyvista)
+- StreamlitPyVista: Streamlit integration wrapper for interactive visualization (optional, requires pyvista)
+- PlotlyCharts: 2D plotting utilities for convergence, residuals, and statistics (always available)
+- ExportRenderer: High-quality image and animation export functionality (optional, requires pyvista)
+- Utils: Mesh conversion, optimization, and caching utilities (optional, requires pyvista)
+- preview_basic: Basic 3D preview using Plotly (always available)
 """
 
-from .pyvista_viewer import PyVistaViewer
-from .streamlit_pyvista import StreamlitPyVista
+# Always available - Plotly-based visualization (no heavy dependencies)
 from .plotly_charts import PlotlyCharts
-from .export_renderer import ExportRenderer
-from .utils import (
-    MeshConverter,
-    MeshOptimizer,
-    MeshCache,
-    ColorMapUtils,
-    convert_mesh,
-    optimize_for_display
-)
+from .preview_basic import plot_geometry_data, plot_mesh_3d, create_camera_controls
 
 __version__ = "1.0.0"
 __all__ = [
-    "PyVistaViewer",
-    "StreamlitPyVista",
     "PlotlyCharts",
-    "ExportRenderer",
-    "MeshConverter",
-    "MeshOptimizer",
-    "MeshCache",
-    "ColorMapUtils",
-    "convert_mesh",
-    "optimize_for_display",
+    "plot_geometry_data",
+    "plot_mesh_3d",
+    "create_camera_controls",
 ]
+
+# Optional PyVista-based components (heavy 3D libraries)
+# These are only available if pyvista is installed
+try:
+    from .pyvista_viewer import PyVistaViewer
+    __all__.append("PyVistaViewer")
+    PYVISTA_VIEWER_AVAILABLE = True
+except ImportError:
+    PyVistaViewer = None
+    PYVISTA_VIEWER_AVAILABLE = False
+
+try:
+    from .streamlit_pyvista import StreamlitPyVista
+    __all__.append("StreamlitPyVista")
+    STREAMLIT_PYVISTA_AVAILABLE = True
+except ImportError:
+    StreamlitPyVista = None
+    STREAMLIT_PYVISTA_AVAILABLE = False
+
+try:
+    from .export_renderer import ExportRenderer
+    __all__.append("ExportRenderer")
+    EXPORT_RENDERER_AVAILABLE = True
+except ImportError:
+    ExportRenderer = None
+    EXPORT_RENDERER_AVAILABLE = False
+
+try:
+    from .utils import (
+        MeshConverter,
+        MeshOptimizer,
+        MeshCache,
+        ColorMapUtils,
+        convert_mesh,
+        optimize_for_display
+    )
+    __all__.extend([
+        "MeshConverter",
+        "MeshOptimizer",
+        "MeshCache",
+        "ColorMapUtils",
+        "convert_mesh",
+        "optimize_for_display",
+    ])
+    UTILS_AVAILABLE = True
+except ImportError:
+    MeshConverter = None
+    MeshOptimizer = None
+    MeshCache = None
+    ColorMapUtils = None
+    convert_mesh = None
+    optimize_for_display = None
+    UTILS_AVAILABLE = False

--- a/src/visualization/pyvista_viewer.py
+++ b/src/visualization/pyvista_viewer.py
@@ -3,13 +3,28 @@ PyVista-based 3D visualization engine for CAD models and CFD results.
 
 This module provides the core PyVistaViewer class for rendering CAD geometries,
 CFD simulation results, and mesh quality visualizations.
+
+NOTE: This module requires PyVista to be installed. It is optional and may not
+be available in all deployment environments (e.g., Streamlit Cloud).
 """
 
+from __future__ import annotations
+
 import numpy as np
-import pyvista as pv
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING, Any
 from pathlib import Path
 import warnings
+
+# Use TYPE_CHECKING to avoid runtime import errors while preserving type hints
+if TYPE_CHECKING:
+    import pyvista as pv
+
+try:
+    import pyvista as pv
+    PYVISTA_AVAILABLE = True
+except ImportError:
+    PYVISTA_AVAILABLE = False
+    pv = None  # type: ignore
 
 
 class PyVistaViewer:
@@ -26,7 +41,15 @@ class PyVistaViewer:
 
         Args:
             theme: PyVista theme ('default', 'dark', 'document', 'paraview')
+
+        Raises:
+            ImportError: If PyVista is not available
         """
+        if not PYVISTA_AVAILABLE:
+            raise ImportError(
+                "PyVista is not available. This module requires PyVista to be installed. "
+                "Install with: pip install pyvista"
+            )
         self.theme = theme
         pv.set_plot_theme(theme)
 
@@ -450,7 +473,7 @@ class PyVistaViewer:
         return mesh
 
     @staticmethod
-    def create_sample_mesh(mesh_type: str = 'sphere') -> pv.PolyData:
+    def create_sample_mesh(mesh_type: str = 'sphere'):
         """
         Create sample mesh for testing and demonstrations.
 
@@ -459,7 +482,17 @@ class PyVistaViewer:
 
         Returns:
             pv.PolyData: Sample mesh
+
+        Raises:
+            ImportError: If PyVista is not available
+            ValueError: If mesh_type is unknown
         """
+        if not PYVISTA_AVAILABLE:
+            raise ImportError(
+                "PyVista is not available. Cannot create sample mesh. "
+                "Install with: pip install pyvista"
+            )
+
         if mesh_type == 'sphere':
             return pv.Sphere(radius=1.0, theta_resolution=30, phi_resolution=30)
         elif mesh_type == 'cube':


### PR DESCRIPTION
…it Cloud

This commit resolves import errors in src/visualization module by making all PyVista-dependent modules optional while keeping Plotly-based visualization always available.

Changes:
- src/visualization/__init__.py:
  * Wrapped all PyVista imports (pyvista_viewer, streamlit_pyvista, export_renderer, utils) in try/except blocks
  * Made plotly_charts and preview_basic always available (no PyVista)
  * Added availability flags (PYVISTA_VIEWER_AVAILABLE, etc.)
  * Only export successfully imported modules to __all__

- src/visualization/pyvista_viewer.py:
  * Added 'from __future__ import annotations' for deferred type evaluation
  * Used TYPE_CHECKING guard for PyVista type hints
  * Added runtime checks in __init__ and create_sample_mesh
  * Graceful fallback when PyVista is not available

Impact:
- Fixes import chain: app.py → ui.app → ui.file_import → visualization.preview_basic
- Core 3D preview using Plotly works without PyVista
- App can now run on Streamlit Cloud without heavy 3D libraries
- PyVista features available when library is installed locally

Testing:
✓ src.visualization imports successfully
✓ plot_geometry_data and create_camera_controls available ✓ src.ui.file_import imports without errors
✓ All visualization features gracefully degrade