### PR TITLE
fix: Add deferred annotations to prevent NameError when build123d una…

### DIFF
--- a/src/cad/build123d_engine.py
+++ b/src/cad/build123d_engine.py
@@ -5,7 +5,8 @@ This module provides a comprehensive interface for creating CAD models using
 the build123d library, supporting primitives, operations, and boolean operations.
 """
 
-from typing import Dict, Any, Optional, Union, List
+from __future__ import annotations
+from typing import Dict, Any, Optional, Union, List, TYPE_CHECKING
 from pathlib import Path
 import logging
 

--- a/src/cad/cad_validator.py
+++ b/src/cad/cad_validator.py
@@ -6,7 +6,8 @@ issues, and suggest fixes for problems like invalid volumes, self-intersections,
 and non-manifold geometry.
 """
 
-from typing import List, Optional, Any, Dict
+from __future__ import annotations
+from typing import List, Optional, Any, Dict, TYPE_CHECKING
 from dataclasses import dataclass, field
 import logging
 


### PR DESCRIPTION
…vailable

CRITICAL FIX for deployment:
- Added 'from __future__ import annotations' to build123d_engine.py
- Added 'from __future__ import annotations' to cad_validator.py
- Prevents NameError: name 'Part' is not defined when build123d not installed
- All build123d imports are now properly optional with deferred type hints

Fixes Streamlit Cloud deployment error at build123d_engine.py:43