### PR TITLE
fix: Add packages.txt with OpenGL system dependencies for Streamlit C…

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -1,0 +1,6 @@
+libgl1-mesa-glx
+libglib2.0-0
+libsm6
+libxext6
+libxrender-dev
+libgomp1


### PR DESCRIPTION
…loud

Add libgl1-mesa-glx and related system packages to fix 'libGL.so.1: cannot open shared object file' error on Streamlit Cloud deployment. This resolves the CAD Generation modules availability issue.