### PR TITLE
fix: Enable Zoo.dev 402 fallback + prominent UI status display

### DIFF
--- a/src/cad/model_generator.py
+++ b/src/cad/model_generator.py
@@ -1060,6 +1060,10 @@ Return ONLY valid JSON."""
                 metadata={'engine': 'zoo'}
             )
 
+        except PaymentRequiredError:
+            # Re-raise PaymentRequiredError to trigger fallback mechanism
+            logger.warning("Zoo.dev PaymentRequiredError - re-raising for fallback")
+            raise
         except Exception as e:
             logger.error(f"Zoo.dev generation failed: {e}")
             return CADGenerationResult(


### PR DESCRIPTION
CRITICAL FIX: Zoo.dev 402 error was being caught but NOT triggering fallback

Fixed Issues:
1. **Fallback Mechanism**: _generate_with_zoo() was catching PaymentRequiredError with generic Exception handler and returning failed result instead of re-raising. Now explicitly re-raises PaymentRequiredError to trigger Build123d fallback.

2. **Prominent Fallback Banner**: Added warning banner at top of results when fallback is active, clearly showing "FALLBACK MODE ACTIVE" with reason.

3. **Generation Method Section**: New metrics display showing:
   - Engine Used (with "Fallback" indicator)
   - Output Type (KCL vs Build123d Part)
   - Export count and formats

4. **Fallback Details Section**: Displays fallback type and reason prominently (not hidden in metadata expander) with user-friendly explanation.

Files Changed:
- src/cad/model_generator.py:1063-1066 - Re-raise PaymentRequiredError
- src/ui/design_studio.py:764-846 - Three-layer fallback status display

Result: Users will now clearly see when and why fallback occurs, and the fallback mechanism will actually execute when Zoo.dev returns 402.